### PR TITLE
Fix for str and bytes concatenation which otherwise fails in Python 3.7

### DIFF
--- a/voice_engine/ec.py
+++ b/voice_engine/ec.py
@@ -44,7 +44,7 @@ class EC(Element):
         self.done = True
 
     def run(self):
-        data = ''
+        data = b''
         frames_bytes = self.frames_size * self.channels * 2
         while not self.done:
             data += self.queue.get()


### PR DESCRIPTION
Running the example `/examples/respeaker_6mic_array_for_pi/aec_ns_kws_doa.py` returns an Exception, as shown below. Running Python 3.7 on a Raspberry Pi 4 with Raspbian Buster. 

```
python aec_ns_kws_doa.py 
['arecord', '-t', 'raw', '-f', 'S16_LE', '-c', '8', '-r', '16000', '-D', 'default', '-q']
Exception in thread Thread-3:
Traceback (most recent call last):
  File "/usr/lib/python3.7/threading.py", line 917, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.7/threading.py", line 865, in run
    self._target(*self._args, **self._kwargs)
  File "/home/pi/.local/lib/python3.7/site-packages/voice_engine/ec.py", line 50, in run
    data += self.queue.get()
TypeError: can only concatenate str (not "bytes") to str

^Carecord: pcm_read:2145: quit
read error: Interrupted system call
```

This can be fixed by making the initial `data = ''` a bytes object by adding a 'b' before the quotes.